### PR TITLE
Changed max value accepted by MAC accounting RRD files to 10gb

### DIFF
--- a/perl/mac-acct.pl
+++ b/perl/mac-acct.pl
@@ -132,8 +132,8 @@ sub create_rrd_archive {
         #special chars replaced by a -, unix doesnt like / in filename
         #64 bits max is 18446744073709551616
         my $cli = " $rrdtool create \'$rrddir/$interface_file_name\' \\
-      DS:INOCTETS:COUNTER:600:0:2.5000000000e+08 \\
-      DS:OUTOCTETS:COUNTER:600:0:2.5000000000e+08 \\
+      DS:INOCTETS:COUNTER:600:0:1.25000000000e+09 \\
+      DS:OUTOCTETS:COUNTER:600:0:1.25000000000e+09 \\
       DS:INUCASTPKTS:COUNTER:600:0:U \\
       DS:OUTUCASTPKTS:COUNTER:600:0:U \\
       RRA:AVERAGE:0.5:1:600 \\


### PR DESCRIPTION
changed max values accepted in RRD definition to a modern value. 2gb to 10gb. Note, if existing RRD files need modifying, use 'rrdtool tune' or the following script to edit the values https://github.com/ctomkow/rrdit/blob/master/rrdit.py