### PR TITLE
Feat/plugin init function

### DIFF
--- a/configurations.php
+++ b/configurations.php
@@ -1184,7 +1184,7 @@ function updatePlugins()
 		{
 			if ($id == $eValue)
 			{
-				if (!$previously_enabled) // Run init function of plugin (if exists), if plugin not previously enabled
+				if (!$previously_enabled) // Run on_enable function of plugin (if exists), if plugin not previously enabled
 				{
 					include_once $curPlugin->get_filename();
 					$className = $curPlugin->get_class_name();

--- a/configurations.php
+++ b/configurations.php
@@ -1168,31 +1168,42 @@ function updateDashboard()
 function updatePlugins()
 {
 	global $tool, $propertyForm;
-	
+
 	$enabledPlugins = $_POST['list'];
-	//print_r($enabledWidgets);
-	
 	$plugins = Plugins::get_plugins();
-	
+
 	$update = true;
 	foreach ($plugins as $id => $value)
 	{
 		$isEnabled = false;
 		$curPlugin = new Plugins($id);
+
+		$previously_enabled = $curPlugin->get_enabled();
+
 		foreach ($enabledPlugins as $eID => $eValue)
 		{
 			if ($id == $eValue)
 			{
+				if (!$previously_enabled) // Run init function of plugin (if exists), if plugin not previously enabled
+				{
+					include_once $curPlugin->get_filename();
+					$className = $curPlugin->get_class_name();
+					$pluginClass = new $className();
+
+					if (method_exists($pluginClass, "init")) {
+						$pluginClass->init();
+					}
+				}
 				$curPlugin->set_enabled(true);
 				$isEnabled = true;
 			}
 		}
-		
+
 		if (!$isEnabled)
 		{
 			$curPlugin->set_enabled(false);
 		}
-		
+
 		if ($curPlugin->update_plugin())
 		{$update = true;}
 		else
@@ -1202,7 +1213,7 @@ function updatePlugins()
 			break;
 		}
 	}
-	
+
 	if($update)
 	{
 		$status="success";

--- a/configurations.php
+++ b/configurations.php
@@ -1190,8 +1190,8 @@ function updatePlugins()
 					$className = $curPlugin->get_class_name();
 					$pluginClass = new $className();
 
-					if (method_exists($pluginClass, "init")) {
-						$pluginClass->init();
+					if (method_exists($pluginClass, "on_enable")) {
+						$pluginClass->on_enable();
 					}
 				}
 				$curPlugin->set_enabled(true);

--- a/plugins/Demo Hello World/plugin.php
+++ b/plugins/Demo Hello World/plugin.php
@@ -4,8 +4,8 @@ class HelloWorld
 	//default content
 	private $content = "<h1>HELLO WORLD!</h1>";
 
-	// initialization function run only when plugin is enabled
-	function init()
+	// initialization function run only when plugin is first enabled
+	function on_enable()
 	{
 		// Run any one-time start-up code (e.g. CREATE TABLE IF NOT EXISTS)
 	}

--- a/plugins/Demo Hello World/plugin.php
+++ b/plugins/Demo Hello World/plugin.php
@@ -3,6 +3,12 @@ class HelloWorld
 {
 	//default content
 	private $content = "<h1>HELLO WORLD!</h1>";
+
+	// initialization function run only when plugin is enabled
+	function init()
+	{
+		// Run any one-time start-up code (e.g. CREATE TABLE IF NOT EXISTS)
+	}
 	
 	//renders the content
 	function get_content()


### PR DESCRIPTION
To support further plugin development, an (optional) on_enable function is now supported in a plugins plugin.php. This allows for running any code only when the plugin is first enabled. The `on_enable()` is run only when the plugin is enabled in the gui (box is checked from an unchecked state, and "enable checked plugins" button is pressed). An `on_enable()` was chosen instead of using a `class __construct()` because the plugin.php class happens to be instantiated multiple times throughout configurations.php. This avoids the initialization code from being called multiple times, unnecessarily.

The main use-case for this functionality is to be able to perform a database `CREATE TABLE IF NOT EXISTS` call to create a DB table that supports the plugin's features. This allows an easy way to create supporting DB tables without having to create an "upgrade.sql" and manually apply it to the DB.

For example, SNMP_Poller plugin requires the `plugin_SNMPPoller_devices` DB table which tracks what devices are to be SNMP polled. This type of device tracking is required for future plugins (e.g. `plugin_MACAccounting_devices` DB table).