### PR TITLE
Tweak/notify by email.php

### DIFF
--- a/notify_by_email.php
+++ b/notify_by_email.php
@@ -33,6 +33,6 @@ $headers = "From: $from \r\n" .
 # Not emailing for now!
 # Feb 4, 2014:wq
 #
-#mail($to, $subject, $message, $headers);
+mail($to, $subject, $message, $headers);
 
 ?>

--- a/plugins/ChangeManager/plugin.php
+++ b/plugins/ChangeManager/plugin.php
@@ -604,8 +604,8 @@ class ChangeManager
 
 		$html_content .= $form->ShowForm(1);
 
-		$mail_from = "BCNET CMDB Account <scripts@bc.net>";
-		$mail_to = "noc@bc.net";
+		$mail_from = "Netharbour Account <xx@xx.xx>";
+		$mail_to = "xx@xx.xx";
 		$mail_headers = "From: $mail_from\r\n" .
 		"Reply-To: $mail_from\r\n" .
 		"X-Mailer: Network Change Report Mailer\n";

--- a/plugins/SNMP_Poller/snmp_poller.pl
+++ b/plugins/SNMP_Poller/snmp_poller.pl
@@ -392,8 +392,8 @@ sub send_mail {
 	my $mailcontent = shift;
 	if ($mailcontent ne '') {
                 open (MAIL, "|/usr/sbin/sendmail -oi -t");
-                print MAIL "From: NetHarbour <andree.toonk\@bc.net>\n"; ## don't forget to escape the @
-                print MAIL "To: andree.toonk\@bc.net\n";
+                print MAIL "From: NetHarbour <xx\@xx.xx>\n"; ## don't forget to escape the @
+                print MAIL "To: xx\@xx.xx\n";
                 print MAIL "Subject: Interface errors detected on $device\n";
                 print MAIL "\n";
                 print MAIL "There were Interface errors detected, see detail below:\n\n";


### PR DESCRIPTION
This change ensures that when an event check is triggered (after being manually created through the GUI), an email will be sent. Note: `notify_by_email.php` is only used by user-created events (`Events.php`). Any other email notifications invoke `/usr/sbin/sendmail` directly (e.g. perl scripts) or uses PHP's `mail()` function.

Also, I removed any hard-coded emails I found within the code (not from commented out sections though). See below.

ChangeManager/plugin.php: removed the bc.net email. This will need to be set manually by the administrator.

SNMP_Poller/snmp_poller.pl: removed the bc.net email in the `send_mail` function. The function is not called anywhere in the script anyway, but just in case it is used at some point.

