### PR TITLE
Refac/just in time 32bit counter polling

### DIFF
--- a/plugins/SNMP_Poller/snmp_poller.pl
+++ b/plugins/SNMP_Poller/snmp_poller.pl
@@ -148,14 +148,8 @@ my %ifHCOutUcastPkts = get_ifHCOutUcastPkts();
 
 
 ###### 32 bit counters ############
-my %ifInOctets = get_ifInOctets();
-my %ifOutOctets =  get_ifOutOctets();
-
 my %ifInErrors =  get_ifInErrors();
 my %ifOutErrors = get_ifOutErrors();
-
-my %ifInUcastPkts = get_ifInUcastPkts();
-my %ifOutUcastPkts = get_ifOutUcastPkts();
 
 my %ifInNUcastPkts =  get_ifInNUcastPkts();
 my %ifOutNUcastPkts = get_ifOutNUcastPkts();
@@ -177,6 +171,12 @@ for my $int (sort { $index{$a} <=> $index{$b} }keys %index ) {
 	};
 
 	my $ifOperStatus = $OperStatus{$int};
+
+	# defining 32 bit counter hashes as empty for this interface, if required they will be populated just in time
+	my %ifInOctets = ();
+	my %ifOutOctets = ();
+	my %ifInUcastPkts = ();
+	my %ifOutUcastPkts = ();
 
 	## RRD Stuff
 	#first check if rrd file exist, if not create
@@ -224,7 +224,15 @@ for my $int (sort { $index{$a} <=> $index{$b} }keys %index ) {
 			$update .= ":" . $ifOutNUcastPkts{$int};
 		}
 			
-	} elsif ((defined($ifInOctets{$int})) && (defined($ifOutOctets{$int}))) {
+	} else {
+		# just in time, collect 32 bit counters for this interface because 64 bit don't exist
+		%ifInOctets = get_ifInOctets($int);
+		%ifOutOctets =  get_ifOutOctets($int);
+		%ifInUcastPkts = get_ifInUcastPkts($int);
+		%ifOutUcastPkts = get_ifOutUcastPkts($int);
+	}
+
+	if ((defined($ifInOctets{$int})) && (defined($ifOutOctets{$int}))) {
 		##### This means we're using 32bit counters
 		$update = "N:$ifInOctets{$int}:$ifOutOctets{$int}";
 		if (!defined($ifInErrors{$int})) {
@@ -924,10 +932,10 @@ sub get_ifHCOutOctets {
 }
 
 sub get_ifOutOctets {
-	
 	# ifindex and ifHCOutOctets 32 bits
+	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutOctets";
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutOctets." . $int;
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;
@@ -1017,8 +1025,9 @@ sub get_ifHCOutUcastPkts {
 
 sub get_ifInUcastPkts {
 	# ifindex and ifHCInUcastPkts 32 bits
+	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInUcastPkts";
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInUcastPkts." . $int;
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;
@@ -1034,8 +1043,9 @@ sub get_ifInUcastPkts {
 
 sub get_ifOutUcastPkts {
 	# ifindex and ifOutUcastPkts 32 bits
+	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutUcastPkts";
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutUcastPkts." . $int;
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;
@@ -1107,8 +1117,9 @@ sub get_ifHCInOctets {
 
 sub get_ifInOctets {
 	# ifindex and inoctets 64 bits
+	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInOctets";
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInOctets." . $int;
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;

--- a/plugins/SNMP_Poller/snmp_poller.pl
+++ b/plugins/SNMP_Poller/snmp_poller.pl
@@ -265,7 +265,9 @@ for my $int (sort { $index{$a} <=> $index{$b} }keys %index ) {
 		} else {
 			$update .= ":" . $ifOutNUcastPkts{$int};
 		}
-	} else {
+	}
+
+	if ((!defined($ifHCInOctets{$int})) && (!defined($ifHCOutOctets{$int})) && (!defined($ifInOctets{$int})) && (!defined($ifOutOctets{$int}))) {
 		$name = $name || '';
 		$ifalias = $ifalias || '';
 		$int = $int || '';

--- a/plugins/SNMP_Poller/snmp_poller.pl
+++ b/plugins/SNMP_Poller/snmp_poller.pl
@@ -935,7 +935,7 @@ sub get_ifOutOctets {
 	# ifindex and ifHCOutOctets 32 bits
 	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutOctets." . $int;
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutOctets.$int";
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;
@@ -1027,7 +1027,7 @@ sub get_ifInUcastPkts {
 	# ifindex and ifHCInUcastPkts 32 bits
 	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInUcastPkts." . $int;
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInUcastPkts.$int";
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;
@@ -1045,7 +1045,7 @@ sub get_ifOutUcastPkts {
 	# ifindex and ifOutUcastPkts 32 bits
 	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutUcastPkts." . $int;
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifOutUcastPkts.$int";
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;
@@ -1119,7 +1119,7 @@ sub get_ifInOctets {
 	# ifindex and inoctets 64 bits
 	my $int = shift;
 	my %snmpdata;
-	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInOctets." . $int;
+	my $cli = "$snmpwalk -v 2c -c $community $fqdn IF-MIB::ifInOctets.$int";
 	my @results = `$cli`;
 	foreach my $line (@results) {
 		chomp $line;


### PR DESCRIPTION
Due to heavy polling on some of our core routers, this PR looks to reduce SNMP polling while maintaining full application functionality. This PR collects 64bit counters first, then in the unlikely event 64bit counters don't exist, collects 32bit counters.

--

I noticed that `snmp_poller.pl` polls for both 32bit and 64bit counters, and if 64bit counters exist, 64bit are used and the collected 32bit counters are ignored. While this might have made sense years ago due to wide spread use of 32bit counters on slow interfaces, most equipment of the last decade supports 64bit counters.

According to Interfaces Group MIB RFC 2863 section 3.1.6 Counter size (https://tools.ietf.org/html/rfc2863#section-3.1.6), interfaces that are >=20mbps MUST support 64bit octet counters.
```
   For interfaces that operate at 20,000,000 (20 million) bits per
   second or less, 32-bit byte and packet counters MUST be supported.
   For interfaces that operate faster than 20,000,000 bits/second, and
   slower than 650,000,000 bits/second, 32-bit packet counters MUST be
   supported and 64-bit octet counters MUST be supported.  For
   interfaces that operate at 650,000,000 bits/second or faster, 64-bit
   packet counters AND 64-bit octet counters MUST be supported.
```
However, there are still slow interfaces on some hardware that only supports 32bit counters. To handle this, the 32bit counters are collected just it time. Meaning, if no 64bit counters exist, then attempt to collect 32bit counters (only for the interfaces that need to).