### PR TITLE
Add retry logic when clearing event to overcome sql deadlock

### DIFF
--- a/classes/Event.php
+++ b/classes/Event.php
@@ -295,7 +295,23 @@ class Event {
 				$query_where AND
 				active = '1';
 			";
-		$result = mysql_query($alert_query) or error_log('Error, query failed. ' . mysql_error() ." $alert_query");
+		// mysql documentations suggest that in case of a deadlock
+		// the client should retry automatically, doing 3 times
+		$retry = 1;
+		while ( $retry <= 3 ){
+			$result = mysql_query($alert_query);
+			if (!$result) {
+				error_log('Error, query failed. Try '. $retry . ' - ' . mysql_error() ." $alert_query");
+				if ( strpos(mysql_error(), "Deadlock") == false ) {
+					// Only retry when Deadlock error
+					return false;
+				}
+				$retry++;
+			} else {
+				break;
+			}
+		}
+        $result = mysql_query($alert_query) or error_log('Error, query failed. ' . mysql_error() ." $alert_query");
 		return $result;
 	}
 
@@ -780,4 +796,3 @@ class Event {
 
 
 }
-

--- a/classes/Event.php
+++ b/classes/Event.php
@@ -253,8 +253,13 @@ class Event {
 			return $obj->event_id;
 		} elseif (mysql_num_rows($result) > 1)  {
 			error_log("More than 1 row returned in event_exists(). query: $alert_query");
-			$obj = mysql_fetch_object($result);
-			return $obj->event_id;
+			// Because more than one event exists, we clear all of them
+			// so we can insert a clean one
+			$clear_event_res = $this->clear_event();
+			if ( $clear_event_res == false ){
+				error_log('Clear event in event_exists() was not successful.');
+			}
+			return false;
 		} else {
 			$this->error = "Undefined state in event_exists()";
 			error_log("Undefined state in event_exists()");


### PR DESCRIPTION
In some race conditions, when clearing an event got a deadlock event and the event was active more than one time.
This retry logic mitigates the problem by retrying several (3) times.
Also, when there is no transition state, but duplicated active events are detected, they are cleaned so a new one will be inserted.