### PR TITLE
plugin refresh bug

### DIFF
--- a/configurations.php
+++ b/configurations.php
@@ -772,7 +772,17 @@ function displayPaths() {
 
 function displayPlugins() {
 	global $tool, $propertyForm;
-	
+
+    if($_GET['mode'] == refreshPlugins)
+    {
+        $dir = "plugins/";
+        $status = checkDirForPlugins($dir);
+        if ($status != true)
+        {
+            $propertyForm->warning("Failed to refresh. Reason: ". $status) ;
+        }
+    }
+
 	$plugins = Plugins::get_plugins();
 	
 	echo "<style>";
@@ -804,16 +814,6 @@ function displayPlugins() {
 			
 		</thead>
 		<tbody>";
-	
-	if($_GET['mode'] == refreshPlugins)
-	{
-		$dir = "plugins/";
-		$status = checkDirForPlugins($dir);
-		if ($status != true)
-		{
-			$propertyForm->warning("Failed to refresh. Reason: ". $status) ;
-		}
-	}
 	
 	foreach ($plugins as $id => $value)
 	{


### PR DESCRIPTION
Moved refresh plugin code to before the get_plugins() code. This will ensure the plugins in the database are updated before they are pulled to display to the user.