### PR TITLE
mac accounting RRD file name based on device id

### DIFF
--- a/plugins/MAC-Accounting/mac_acct.pl
+++ b/plugins/MAC-Accounting/mac_acct.pl
@@ -177,7 +177,7 @@ while ( my $mac = each(%allmacs) ) {
         #print "could not find IP for mac $mac\n";
         next;
     }
-    my $rrd_file = "MAC-ACCT_". $ip ."_device_$fqdn.rrd";
+    my $rrd_file = "MAC-ACCT_". $ip ."_deviceid$device_id.rrd";
     $rrd_file =~ s/([\$\#\@\\\/\s])/-/g;
     create_rrd_archive($rrd_file) if ! -e "$rrddir/$rrd_file";
     my $update = "N:$jnxMacHCInOctets{$mac}:$jnxMacHCOutOctets{$mac}:$jnxMacHCInFrames{$mac}:$jnxMacHCOutFrames{$mac}";

--- a/plugins/MAC-Accounting/plugin.php
+++ b/plugins/MAC-Accounting/plugin.php
@@ -280,7 +280,7 @@ class MACAccounting
         $graphType   = str_replace(" ", "%20", $graphType);
 
         $rrd_dir  = $property->get_property("path_rrddir");
-        $rrdFile  = "$rrd_dir" . "/MAC-ACCT_" . "$ip" . "_device_" . $device->get_device_fqdn() . ".rrd";
+        $rrdFile  = "$rrd_dir" . "/MAC-ACCT_" . "$ip" . "_deviceid" . $id . ".rrd";
 
         $form = $view->tableCreate("auto", 1, true, $header, "900px");
         $view->header = "MAC Accounting";
@@ -334,8 +334,8 @@ class MACAccounting
         $graphType   = str_replace(" ", "%20", $graphType);
 
         $rrd_dir  = $property->get_property("path_rrddir");
-        $rrdFile  = "$rrd_dir" . "/MAC-ACCT_" . "$ip" . "_device_" . $device->get_device_fqdn() . ".rrd";
-        $rrdFileName = "MAC-ACCT_" . "$ip" . "_device_" . $device->get_device_fqdn() . ".rrd";
+        $rrdFile  = "$rrd_dir" . "/MAC-ACCT_" . "$ip" . "_deviceid" . $id . ".rrd";
+        $rrdFileName = "MAC-ACCT_" . "$ip" . "_deviceid" . $id . ".rrd";
 
         $form = $view->tableCreate("auto", 1, true, $header, "900px");
         $view->header = "MAC Accounting";


### PR DESCRIPTION
changed rrd file name to depend on device ID as opposed to the origial fqdn dependency. Will prevent future issues if a device fqdn gets changed.

If mac accounting plugin has already been implemented, then the RRD files need to be renamed.
`rename "MAC-ACCT*<fqdn>.rrd" "deviceid<id_num>" *.rrd`