### PR TITLE
IPv6 address column added to mac accounting

### DIFF
--- a/plugins/MAC-Accounting/model.php
+++ b/plugins/MAC-Accounting/model.php
@@ -48,6 +48,9 @@ class Model
                 `mac_address`     varchar(20) NOT NULL COMMENT 'mac address',
                 `resolved_ip`     varchar(255) NOT NULL COMMENT 'DNS name of harvested ip',
                 `org_name`        varchar(200) NOT NULL COMMENT 'Org name derived from asn',
+                `ipv6_address`    varchar(50) NOT NULL COMMENT 'ipv6 address',
+                `last_seen`       timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                `active`          tinyint(3) NOT NULL DEFAULT 1 COMMENT 'is mac or ip still seen?',
                 PRIMARY KEY (`device_id`, `ip_address`, `mac_address`),
                 CONSTRAINT `plugin_MACAccounting_info_ibfk_1` FOREIGN KEY (`device_id`) REFERENCES `plugin_MACAccounting_devices` (`device_id`) ON DELETE CASCADE ON UPDATE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='mac and ip details for MAC Accounting'
@@ -110,7 +113,8 @@ class Model
                    plugin_MACAccounting_info.ip_address, 
                    plugin_MACAccounting_info.mac_address, 
                    plugin_MACAccounting_info.resolved_ip,
-                   plugin_MACAccounting_info.org_name
+                   plugin_MACAccounting_info.org_name,
+                   plugin_MACAccounting_info.ipv6_address
             FROM plugin_MACAccounting_info
             WHERE plugin_MACAccounting_info.device_id = '$id'";
         $result = mysql_query($query);

--- a/plugins/MAC-Accounting/plugin.php
+++ b/plugins/MAC-Accounting/plugin.php
@@ -224,11 +224,12 @@ class MACAccounting
         $header    = array(
             "MAC Address",
             "IP Address",
+            "IPv6 Address",
             "FQDN",
             "Org Name"
         );
 
-        $form = $view->tableCreate("auto", 4, true, $header, "900px");
+        $form = $view->tableCreate("auto", 5, true, $header, "900px");
 
         $result = $model->selMACAcctInfo($id);
         if (!$result) {
@@ -240,7 +241,7 @@ class MACAccounting
 
         // add table data and generate device links
         while ($obj = $model->fetchObject($result)) {
-            array_push ($tableData, $obj->mac_address, $obj->ip_address, $obj->resolved_ip, $obj->org_name);
+            array_push ($tableData, $obj->mac_address, $obj->ip_address, $obj->ipv6_address, $obj->resolved_ip, $obj->org_name);
             $url2 = $url . "&action=show_macaccounting_detail&device_id=" . $id . "&ip=$obj->ip_address";
             array_push($handler, "handleEvent('$url2')");
         }


### PR DESCRIPTION
Added ipv6 address column to mac accounting data. Pulled the data from the existing JSON that was pulled from peeringDB to prevent unnecessary API calls.

Note, this includes the merge conflict that will occur with PR https://github.com/netharbour/netharbour/pull/26