### PR TITLE
standarize all perl scripts shebang.

### DIFF
--- a/check-scripts/check_bgp.pl
+++ b/check-scripts/check_bgp.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # check_bgp - nagios plugin 
 #

--- a/check-scripts/check_if_threshold.pl
+++ b/check-scripts/check_if_threshold.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 #  check_if_threshold.pl
 #  This script is used to check if interfaces are close to reaching threshold values

--- a/check-scripts/check_juniper_jseries.pl
+++ b/check-scripts/check_juniper_jseries.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/check-scripts/check_juniper_rpm.pl
+++ b/check-scripts/check_juniper_rpm.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/check-scripts/check_junos_bgp_v6_peer.pl
+++ b/check-scripts/check_junos_bgp_v6_peer.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/check-scripts/check_mx.pl
+++ b/check-scripts/check_mx.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/check-scripts/check_ospf.0.1.pl
+++ b/check-scripts/check_ospf.0.1.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # check_ospf - nagios plugin 
 #

--- a/check-scripts/cmdb_check_ifstatus.pl
+++ b/check-scripts/cmdb_check_ifstatus.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # check_ifoperstatus.pl - nagios plugin 
 #

--- a/check-scripts/jflowcheck.pl
+++ b/check-scripts/jflowcheck.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/check-scripts/ping.pl
+++ b/check-scripts/ping.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/perl/mac-acct.pl
+++ b/perl/mac-acct.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 #use strict;
 #use warnings;

--- a/plugins/FirewallCounters/fwcounters.pl
+++ b/plugins/FirewallCounters/fwcounters.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/plugins/SCU-Accounting/scu_dcu.pl
+++ b/plugins/SCU-Accounting/scu_dcu.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/plugins/SNMP_Poller/check_threshold.pl
+++ b/plugins/SNMP_Poller/check_threshold.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/plugins/SNMP_Poller/fw-acct.pl
+++ b/plugins/SNMP_Poller/fw-acct.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/plugins/SNMP_Poller/kill_rrd_spikes.pl
+++ b/plugins/SNMP_Poller/kill_rrd_spikes.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 # This is a  modified version of removespikes.pl found at 
 # http://oss.oetiker.ch/rrdtool/pub/contrib/

--- a/plugins/weathermap/random-bits/auto-overlib.pl
+++ b/plugins/weathermap/random-bits/auto-overlib.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use DBI;
 


### PR DESCRIPTION
The first perl found in PATH will be used. This helps environments that have a different perl installed than the default one shipped with.