### PR TITLE
added case sensitive collation to accounting_sources

### DIFF
--- a/netharbour.sql
+++ b/netharbour.sql
@@ -521,7 +521,7 @@ CREATE TABLE `accounting_sources` (
   UNIQUE KEY `file` (`file`),
   KEY `device_id` (`device_id`),
   CONSTRAINT `accounting_sources_ibfk_1` FOREIGN KEY (`device_id`) REFERENCES `Devices` (`device_id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1002 DEFAULT CHARSET=latin1 COMMENT='Table for accounting / scu';
+) ENGINE=InnoDB AUTO_INCREMENT=1002 DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs COMMENT='Table for accounting / scu';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
The default collation for `accounting_sources` is `latin1_swedish_ci`, meaning it's case in-sensitive. This causes issues with the scu plugin. Within the scu plugin, the interface name is written as part of the rrd file name, therefore, a rename of an interface's capitalization causes a new RRD file to be written, but the db update fails because of an existing `UNIQUE` element.

There should be proper data normalization done before db `INSERT`s. However, changing the structure of existing data in the db would involve ensuring all existing data is processed. Since there is no packaging mechanism for deploying updates, a simpler solution is suggested.

A simpler fix is to modify the collation of `accounting_sources` to `latin1_general_cs` (case-sensitive).

Modify an existing database.
`alter table accounting_sources convert to character set latin1 collate latin1_general_cs;`